### PR TITLE
packagetest project updated to reference Crc32C v1.1.5.

### DIFF
--- a/packagetest/packages.config
+++ b/packagetest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Crc32C" version="1.1.0" targetFramework="native" />
+  <package id="Crc32C" version="1.1.5" targetFramework="native" />
 </packages>

--- a/packagetest/packagetest.vcxproj
+++ b/packagetest/packagetest.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Crc32C.1.1.0\build\native\Crc32C.props" Condition="Exists('..\packages\Crc32C.1.1.0\build\native\Crc32C.props')" />
+  <Import Project="..\packages\Crc32C.1.1.5\build\native\Crc32C.props" Condition="Exists('..\packages\Crc32C.1.1.5\build\native\Crc32C.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -165,6 +165,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Crc32C.1.1.0\build\native\Crc32C.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Crc32C.1.1.0\build\native\Crc32C.props'))" />
+    <Error Condition="!Exists('..\packages\Crc32C.1.1.5\build\native\Crc32C.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Crc32C.1.1.5\build\native\Crc32C.props'))" />
   </Target>
 </Project>


### PR DESCRIPTION
This change **does not** require the NuGet package republishing.